### PR TITLE
Fix session metric and add context window utilization tracking

### DIFF
--- a/CLAUDE_OBSERVABILITY.md
+++ b/CLAUDE_OBSERVABILITY.md
@@ -328,6 +328,42 @@ The event data provides detailed insights into Claude Code interactions:
 
 **Performance Monitoring**: Track API request durations and tool execution times to identify performance bottlenecks.
 
+### Derived Metrics
+
+Some useful metrics can be calculated from the raw telemetry data:
+
+#### Context Window Utilization
+
+Calculate the percentage of context window used per API request. This helps identify when sessions are approaching context limits.
+
+**From Loki (per-request granularity):**
+
+```logql
+# Average context window utilization % (assumes 200k token context)
+avg_over_time(
+  {service_name="claude-code"} |= "claude_code.api_request"
+  | json
+  | unwrap input_tokens [$__interval]
+) / 200000 * 100
+```
+
+**Attributes available for filtering:**
+* `model`: Filter by model (context limits vary by model)
+* `session_id`: Track utilization per session
+* `organization_id`: Aggregate by organization
+* `user_account_uuid`: Track per-user patterns
+
+**Context window limits by model:**
+| Model | Context Window |
+| ----- | -------------- |
+| claude-opus-4-5-20251101 | 200,000 tokens |
+| claude-sonnet-4-20250514 | 200,000 tokens |
+| claude-haiku-4-5-20251001 | 200,000 tokens |
+
+<Note>
+  High context utilization (>80%) may indicate sessions at risk of hitting context limits. Consider monitoring for alerts when utilization exceeds thresholds.
+</Note>
+
 ## Backend Considerations
 
 Your choice of metrics and logs backends will determine the types of analyses you can perform:

--- a/claude-code-dashboard.json
+++ b/claude-code-dashboard.json
@@ -63,7 +63,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 5,
         "x": 0,
         "y": 1
       },
@@ -86,13 +86,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(claude_code_session_count_total{job=\"otel-collector\"}[1h]))",
+          "expr": "count(count by (session_id)(claude_code_cost_usage_USD_total{job=\"otel-collector\"})) or vector(0)",
           "interval": "",
-          "legendFormat": "Sessions (1h)",
+          "legendFormat": "Sessions",
           "refId": "A"
         }
       ],
-      "title": "Active Sessions (1h)",
+      "title": "Total Sessions",
       "type": "stat"
     },
     {
@@ -129,8 +129,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 6,
+        "w": 5,
+        "x": 5,
         "y": 1
       },
       "id": 2,
@@ -195,8 +195,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 12,
+        "w": 5,
+        "x": 10,
         "y": 1
       },
       "id": 3,
@@ -261,8 +261,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 18,
+        "w": 5,
+        "x": 15,
         "y": 1
       },
       "id": 4,
@@ -291,6 +291,78 @@
         }
       ],
       "title": "Lines of Code (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "max_over_time({service_name=\"claude-code\"} |= \"claude_code.api_request\" | json | unwrap input_tokens [1h]) / 200000 * 100",
+          "interval": "",
+          "legendFormat": "Context %",
+          "refId": "A"
+        }
+      ],
+      "title": "Context Window (Max 1h)",
       "type": "stat"
     },
     {


### PR DESCRIPTION
## Summary

- **Fix session count showing 0**: The `claude_code_session_count_total` metric is documented but not actually emitted by Claude Code. Changed query to derive session count from existing metrics using `count(count by (session_id)(claude_code_cost_usage_USD_total))`.

- **Add context window utilization panel**: New stat panel in dashboard overview showing max context window usage as a percentage with color-coded thresholds (green <50%, yellow 50-70%, orange 70-85%, red >85%).

- **Document derived metrics**: Added new section to `CLAUDE_OBSERVABILITY.md` explaining how to calculate context window utilization from raw telemetry data, including model context limits.

## Test plan

- [ ] Verify session count panel now shows correct count (derives from cost metrics)
- [ ] Verify context window utilization panel displays in overview section
- [ ] Confirm color thresholds work correctly based on utilization percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)